### PR TITLE
Fix for CHR$() on TMS9900: print_char swaps bytes in r2, so we swap b…

### DIFF
--- a/cvbasic.c
+++ b/cvbasic.c
@@ -3481,10 +3481,12 @@ void compile_statement(int check_for_else)
                                 emit_error("syntax error in CHR$");
                             else
                                 get_lex();
-                            if (target == CPU_6502)
+                            if (target == CPU_6502) {
                                 cpu6502_noop("TAX");
-                            else if (target == CPU_9900)
+                            } else if (target == CPU_9900) {
                                 cpu9900_2op("mov", "r0", "r2");
+                                cpu9900_1op("swpb", "r2");
+                            }
                             generic_call("print_char");
                         } else {
                             type = evaluate_expression(1, TYPE_16, 0);


### PR DESCRIPTION
…efore calling. Potentially better ways to do this.