### PR TITLE
- add an EVEN directive before labels in the CPU9900 target. This fix…

### DIFF
--- a/cvbasic.c
+++ b/cvbasic.c
@@ -5735,6 +5735,12 @@ void compile_basic(void)
             } else {
                 label = label_add(name);
             }
+
+            if (target == CPU_9900) {
+                // code MUST be even aligned - most of the time this will do nothing
+                cpu9900_noop("even");
+            }
+
             label->used |= LABEL_DEFINED;
             strcpy(temp, LABEL_PREFIX);
             strcat(temp, name);


### PR DESCRIPTION
…es misaligned code after a data table with an odd number of bytes.