### PR TITLE
- a more intelligent application of EVEN - will apply only to label: …

### DIFF
--- a/cvbasic.c
+++ b/cvbasic.c
@@ -5736,16 +5736,25 @@ void compile_basic(void)
                 label = label_add(name);
             }
 
-            if (target == CPU_9900) {
-                // code MUST be even aligned - most of the time this will do nothing
-                cpu9900_noop("even");
-            }
-
+            // first build up the label into temp
             label->used |= LABEL_DEFINED;
             strcpy(temp, LABEL_PREFIX);
             strcat(temp, name);
-            generic_label(temp);
+
+            // we can look ahead a little - get_lex won't mess with temp[]
+            // and we can use it to tell if the TI port needs to output an EVEN directive
             get_lex();
+
+            if ((target == CPU_9900) && (lex == C_NAME) && (0 == strcmp(name, "PROCEDURE"))) {
+                // code MUST be even aligned
+                // this won't trigger for inline labels, but I don't think inline labels
+                // can become misaligned?
+                cpu9900_noop("even");
+            }
+
+            // now we can emit the label
+            // remember, we already get_lex'd
+            generic_label(temp);
             label_exists = 1;
         }
         if (lex == C_NAME) {


### PR DESCRIPTION
…PROCEDURE now, instead of all labels

This way byte-aligned data tables can remain byte aligned.